### PR TITLE
Bugfix/debian and ubuntu code names in version string

### DIFF
--- a/bin/debian-codename-to-version.sh
+++ b/bin/debian-codename-to-version.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Copyright (C) 2016      by Mihai Moldovan <ionic@ionic.de>
+#
+# This programme is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This programme is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+
+export PATH="${HOME}/bin:${PATH}"
+
+# ${CDPATH} could lead to some very nasty problems. Better unset it.
+unset CDPATH
+
+# Takes a Debian code name and converts it into the
+# corresponding numerical version (based on year and month
+# of the release.)
+# The result is printed as a string with a trailing newline.
+# The return code is either 0, iff mapping was successful,
+# or 1 if the code name is unknown and mapping failed.
+
+typeset -l codename
+codename="${1:?"No code name provided."}"
+
+typeset -l -i ret="0"
+
+case "${codename}" in
+	# The first version number is actually "fake",
+	# but given it's a rolling release,
+	# we can't really do better here.
+	("sid"|"unstable") echo "9999";;
+
+	# FIXME: add "testing" - but how? It's not really
+	# a stable release on its own, but a rolling
+	# release (see sid/unstable above). Yet, it differs
+	# from sid/unstable by not having one unique
+	# code name, but a floating one of the next
+	# stable release. We know the new release number
+	# beforehand, but mapping "testing" to the
+	# upcoming version number means that "testing"s
+	# version number itself would be floating, creating
+	# problems after each new release and requiring an
+	# update. On the other hand, giving "testing" a
+	# fixed version number such as "999" (smaller than
+	# "unstable"s, yet bigger than anything we encountered
+	# so far) would create an inconsistency:
+	# The "testing" code name would have a different
+	# version number than the code-name-to-be-released-
+	# next.
+	# For now and due to the aforementioned problems,
+	# I decided to not handle the "testing" code name
+	# at all.
+	("stretch") echo "9";;
+
+	("jessie") echo "8";;
+	("wheezy") echo "7";;
+	("squeeze") echo "6";;
+	("lenny") echo "5";;
+	("etch") echo "4";;
+	("sarge") echo "3.1";;
+	("woody") echo "3.0";;
+	("potato") echo "2.2";;
+	("slink") echo "2.1";;
+	("hamm") echo "2.0";;
+	("bo") echo "1.3";;
+	("rex") echo "1.2";;
+	("buzz") echo "1.1";;
+
+	(*) ret="1";;
+esac
+
+return "${ret}"

--- a/bin/debian-codename-to-version.sh
+++ b/bin/debian-codename-to-version.sh
@@ -29,10 +29,18 @@ unset CDPATH
 # The return code is either 0, iff mapping was successful,
 # or 1 if the code name is unknown and mapping failed.
 
-typeset -l codename
+# Where supported (BASH 4 and higher), automatically
+# lower-case the codename argument.
+if [ -n "${BASH_VERSINFO[0]}" ] && [ "${BASH_VERSINFO[0]}" -gt 3 ]; then
+	typeset -l codename
+fi
 codename="${1:?"No code name provided."}"
 
-typeset -l -i ret="0"
+if [ -z "${BASH_VERSINFO[0]}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+	codename="$(tr '[:upper:]' '[:lower:]' <<< "${codename}")"
+fi
+
+typeset -i ret="0"
 
 case "${codename}" in
 	# The first version number is actually "fake",
@@ -79,4 +87,4 @@ case "${codename}" in
 	(*) ret="1";;
 esac
 
-return "${ret}"
+exit "${ret}"

--- a/bin/sbuild-deb-package
+++ b/bin/sbuild-deb-package
@@ -233,13 +233,34 @@ build_packages() {
 				}
 
 				# for Ubuntu version is the codename of the distribution release
-				VERSION="${l_CODENAME}"
+				typeset -l codename="${l_CODENAME}"
 
 				# translate the version name for Debian releases
-				[ "x${l_CODENAME}" = "xsid" ] && VERSION="unstable"
-				#[ "x$l_CODENAME" = "xjessie" ] && VERSION=testing
-				#[ "x$l_CODENAME" = "xwheezy" ] && VERSION=stable
-				#[ "x$l_CODENAME" = "xoldstable" ] && VERSION=oldstable
+				[ "x${l_CODENAME}" = "xsid" ] && codename="unstable"
+				#[ "x$l_CODENAME" = "xjessie" ] && codename=testing
+				#[ "x$l_CODENAME" = "xwheezy" ] && codename=stable
+				#[ "x$l_CODENAME" = "xoldstable" ] && codename=oldstable
+
+				typeset -l numerical_version=""
+				typeset -l -i tmp_ret="1"
+				typeset -l pretty_dist=""
+
+				if [ -n "${l_DIST}" ] && [ "${l_DIST}" = "debian" ]; then
+					pretty_dist="Debian"
+					numerical_version="$("${script_path}/debian-codename-to-version.sh" "${codename}")"
+					tmp_ret="${?}"
+				fi
+
+				if [ -n "${l_DIST}" ] && [ "${l_DIST}" = "ubuntu" ]; then
+					pretty_dist="Ubuntu"
+					numerical_version="$("${script_path}/ubuntu-codename-to-version.sh" "${codename}")"
+					tmp_ret="${?}"
+				fi
+
+				if [ "${tmp_ret}" -ne "0" ]; then
+					echo "Error: unable to map code name \"${codename}\" to Debian or Ubuntu numerical versions. Unknown code name or not applicable to distribution \"${dist_pretty}\"? Aborting." >&2
+					exit 1
+				fi
 
 				# modify the section for non-main package builds
 				[ "x${COMPONENT}" != "xmain" ] && {
@@ -249,9 +270,9 @@ build_packages() {
 
 				# modify changelog for this build
 				if [ "${COMPONENT}" != "${COMPONENT_NIGHTLY}" ]; then
-					dch --distribution "${VERSION}" --force-distribution -l "+git${DATE}.${GITREV}+${l_CODENAME}.${COMPONENT}." "Auto-built ${l_DIST} ${l_CODENAME} package for ${REPOS_SERVER} repository (Git commit: ${GIT_OBJECT_ID})."
+					dch --distribution "${codename}" --force-distribution -l "+git${DATE}.${GITREV}+${numerical_version}.${COMPONENT}." "Auto-built ${pretty_dist} ${l_CODENAME} package for ${REPOS_SERVER} repository (Git commit: ${GIT_OBJECT_ID})."
 				else
-					dch --distribution "${VERSION}" --force-distribution -l "~git${DATE}.${GITREV}+${l_CODENAME}.${COMPONENT}." "Development-Snapshot!!! Auto-built ${l_DIST} ${l_CODENAME} package for ${REPOS_SERVER} repository (Git commit: ${GIT_OBJECT_ID})."
+					dch --distribution "${codename}" --force-distribution -l "~git${DATE}.${GITREV}+${numerical_version}.${COMPONENT}." "Development-Snapshot!!! Auto-built ${pretty_dist} ${l_CODENAME} package for ${REPOS_SERVER} repository (Git commit: ${GIT_OBJECT_ID})."
 				fi
 				mkdir -p -- "${PKGDIST}/${l_DIST}/${l_CODENAME}/"{amd64,i386}
 				OTHERMIRROR=""
@@ -268,7 +289,7 @@ build_packages() {
 				cd ..
 				DSCFILE="$(pwd)/$(ls -1 "${PROJECT}_"*.dsc | head -n1)"
 
-				SBUILD_OPTIONS="-n -j2 -sAd ${VERSION} -k ${GPG_KEY} --build-dep-resolver=aptitude"
+				SBUILD_OPTIONS="-n -j2 -sAd ${codename} -k ${GPG_KEY} --build-dep-resolver=aptitude"
 				SBUILD_OPTIONS_64="${SBUILD_OPTIONS} -c arctica-${l_CODENAME}"
 				SBUILD_OPTIONS_32="${SBUILD_OPTIONS} -c arctica-${l_CODENAME}-i386 --arch=i386  --debbuildopts=-B"
 				if [ -n "${SA_OPTION}" ]; then

--- a/bin/sbuild-deb-package
+++ b/bin/sbuild-deb-package
@@ -233,7 +233,11 @@ build_packages() {
 				}
 
 				# for Ubuntu version is the codename of the distribution release
-				typeset -l codename="${l_CODENAME}"
+				if [ -n "${BASH_VERSINFO[0]}" ] && [ "${BASH_VERSINFO[0]}" -gt 3 ]; then
+					typeset -l codename="${l_CODENAME}"
+				else
+					typeset codename="$(tr '[:upper:]' '[:lower:]' <<< "${l_CODENAME}")"
+				fi
 
 				# translate the version name for Debian releases
 				[ "x${l_CODENAME}" = "xsid" ] && codename="unstable"
@@ -241,9 +245,9 @@ build_packages() {
 				#[ "x$l_CODENAME" = "xwheezy" ] && codename=stable
 				#[ "x$l_CODENAME" = "xoldstable" ] && codename=oldstable
 
-				typeset -l numerical_version=""
-				typeset -l -i tmp_ret="1"
-				typeset -l pretty_dist=""
+				typeset numerical_version=""
+				typeset -i tmp_ret="1"
+				typeset pretty_dist=""
 
 				if [ -n "${l_DIST}" ] && [ "${l_DIST}" = "debian" ]; then
 					pretty_dist="Debian"
@@ -257,7 +261,7 @@ build_packages() {
 					tmp_ret="${?}"
 				fi
 
-				if [ "${tmp_ret}" -ne "0" ]; then
+				if [ "${tmp_ret}" -ne "0" ] || [ -z "${numerical_version}" ]; then
 					echo "Error: unable to map code name \"${codename}\" to Debian or Ubuntu numerical versions. Unknown code name or not applicable to distribution \"${dist_pretty}\"? Aborting." >&2
 					exit 1
 				fi

--- a/bin/ubuntu-codename-to-version.sh
+++ b/bin/ubuntu-codename-to-version.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Copyright (C) 2016      by Mihai Moldovan <ionic@ionic.de>
+#
+# This programme is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This programme is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+
+export PATH="${HOME}/bin:${PATH}"
+
+# ${CDPATH} could lead to some very nasty problems. Better unset it.
+unset CDPATH
+
+# Takes a Debian code name and converts it into the
+# corresponding numerical version.
+# The result is printed as a string with a trailing newline.
+# The return code is either 0, iff mapping was successful,
+# or 1 if the code name is unknown and mapping failed.
+
+typeset -l codename
+codename="${1:?"No code name provided."}"
+
+typeset -l -i ret="0"
+
+case "${codename}" in
+	# The first version number is actually "fake",
+	# but given it's a rolling release,
+	# we can't really do better here.
+	("devel") echo "9999";;
+
+	("yakkety") echo "16.10";;
+
+	("xenial") echo "16.04";;
+	("wily") echo "15.10";;
+	("vivid") echo "15.04";;
+	("utopic") echo "14.10";;
+	("trusty") echo "14.04";;
+	("saucy") echo "13.10";;
+	("raring") echo "13.04";;
+	("precise") echo "12.04";;
+	("quantal") echo "12.10";;
+	("oneiric") echo "11.10";;
+	("natty") echo "11.04";;
+	("maverick") echo "10.10";;
+	("lucid") echo "10.04";;
+	("karmic") echo "9.10";;
+	("jaunty") echo "9.04";;
+	("intrepid") echo "8.10";;
+	("hardy") echo "8.04";;
+	("gutsy") echo "7.10";;
+	("feisty") echo "7.04";;
+	("edgy") echo "6.10";;
+	("dapper") echo "6.06";;
+	("breezy") echo "5.10";;
+	("hoary") echo "5.04";;
+	("warty") echo "4.10";;
+
+	(*) ret="1";;
+esac
+
+return "${ret}"

--- a/bin/ubuntu-codename-to-version.sh
+++ b/bin/ubuntu-codename-to-version.sh
@@ -28,10 +28,18 @@ unset CDPATH
 # The return code is either 0, iff mapping was successful,
 # or 1 if the code name is unknown and mapping failed.
 
-typeset -l codename
+# Where supported (BASH 4 and higher), automatically
+# lower-case the codename argument.
+if [ -n "${BASH_VERSINFO[0]}" ] && [ "${BASH_VERSINFO[0]}" -gt 3 ]; then
+	typeset -l codename
+fi
 codename="${1:?"No code name provided."}"
 
-typeset -l -i ret="0"
+if [ -z "${BASH_VERSINFO[0]}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+	codename="$(tr '[:upper:]' '[:lower:]' <<< "${codename}")"
+fi
+
+typeset -i ret="0"
 
 case "${codename}" in
 	# The first version number is actually "fake",
@@ -69,4 +77,4 @@ case "${codename}" in
 	(*) ret="1";;
 esac
 
-return "${ret}"
+exit "${ret}"


### PR DESCRIPTION
Changes the package versioning scheme to avoid problems during dist-upgrades on Debian and Ubuntu without the need to revbump all packages.

Please make sure to read the top-most commit message carefully to understand what merging this PR implies.
